### PR TITLE
CSV Hardening

### DIFF
--- a/src/main/java/seedu/duke/commands/AddCommand.java
+++ b/src/main/java/seedu/duke/commands/AddCommand.java
@@ -41,7 +41,7 @@ public class AddCommand extends Command {
                     item.setCategory(category);
                 }
             } catch (NullPointerException e) {
-                item.setCategory("uncategorised");
+                item.setCategory("Uncategorized");
             }
             try {
                 CategoryCommand.updateItemCategory(item, item.getCategory(), item.getCategory());

--- a/src/main/java/seedu/duke/commands/FilterCommand.java
+++ b/src/main/java/seedu/duke/commands/FilterCommand.java
@@ -10,6 +10,10 @@ import java.util.ArrayList;
  * Represents the command to filter items in the inventory.
  */
 public class FilterCommand extends Command {
+    private static final String LESS_THAN_FLAG = "p/lt";
+    private static final String GREATER_THAN_FLAG = "p/gt";
+    private static final String LESS_OR_EQUAL_THAN_FLAG = "p/let";
+    private static final String GREATER_OR_EQUAL_THAN_FLAG = "p/get";
     private String filterType;
     private String filterValue;
     private Double filterPrice;
@@ -73,22 +77,22 @@ public class FilterCommand extends Command {
         ArrayList<Item> filteredItems = new ArrayList<>();
         for (Item item : itemInventory) {
             switch (mode) {
-            case "p/lt":
+            case LESS_THAN_FLAG:
                 if (item.getPrice() < price) {
                     filteredItems.add(item);
                 }
                 break;
-            case "p/gt":
+            case GREATER_THAN_FLAG:
                 if (item.getPrice() > price) {
                     filteredItems.add(item);
                 }
                 break;
-            case "p/let":
+            case LESS_OR_EQUAL_THAN_FLAG:
                 if (item.getPrice() <= price) {
                     filteredItems.add(item);
                 }
                 break;
-            case "p/get":
+            case GREATER_OR_EQUAL_THAN_FLAG:
                 if (item.getPrice() >= price) {
                     filteredItems.add(item);
                 }

--- a/src/main/java/seedu/duke/utils/SessionManager.java
+++ b/src/main/java/seedu/duke/utils/SessionManager.java
@@ -2,6 +2,7 @@ package seedu.duke.utils;
 
 import seedu.duke.objects.AlertList;
 import seedu.duke.objects.Inventory;
+import seedu.duke.types.Types;
 
 /**
  * Class to manage the session of the program and its storage features.
@@ -18,7 +19,7 @@ public class SessionManager {
     }
 
     public static Inventory getSession() {
-        return Storage.readCSV();
+        return Storage.readCSV(Types.SESSIONFILEPATH);
     }
 
     public static AlertList getSessionAlerts() {

--- a/src/main/java/seedu/duke/utils/Storage.java
+++ b/src/main/java/seedu/duke/utils/Storage.java
@@ -51,7 +51,7 @@ public class Storage {
      *
      * @return Inventory object
      */
-    public static Inventory readCSV(String filePath) {
+    public static synchronized Inventory readCSV(String filePath) {
         try {
             BufferedReader reader = new BufferedReader(new FileReader(filePath));
             Types.FileHealth fileStatus = checkFileValid(filePath, VALID_DATAROW_REGEX);
@@ -137,7 +137,7 @@ public class Storage {
      *
      * @param currentInventory Current inventory
      */
-    public static void writeCSV(final Inventory currentInventory) {
+    public static synchronized void writeCSV(final Inventory currentInventory) {
         isStorageWriteDone = false;
         try {
             File dataFolder = new File("./data");
@@ -163,7 +163,7 @@ public class Storage {
         isStorageWriteDone = true;
     }
 
-    public static void writeCSV(final AlertList alertList) {
+    public static synchronized void writeCSV(final AlertList alertList) {
         try {
             File dataFolder = new File("./data");
             if (!dataFolder.exists()) {
@@ -192,7 +192,7 @@ public class Storage {
 
     }
 
-    public static AlertList readAlertCSV() {
+    public static synchronized AlertList readAlertCSV() {
         try {
             BufferedReader reader = new BufferedReader(new FileReader(Types.ALERTFILEPATH));
             String line = reader.readLine();
@@ -254,7 +254,7 @@ public class Storage {
      * @param path File path
      * @return FileHealth enum that indicates the state of the file (MISSING/CORRUPT/OK)
      */
-    public static Types.FileHealth checkFileValid(final String path, String validRow) {
+    public static synchronized Types.FileHealth checkFileValid(final String path, String validRow) {
         File file = new File(path);
 
         // Check if directory exists
@@ -293,7 +293,7 @@ public class Storage {
      *
      * @return String that will be printed which indicates the state of the file (MISSING/CORRUPT/OK/UNKNOWN)
      */
-    public static String checkDataFileExist(boolean isInventoryData) {
+    public static synchronized String checkDataFileExist(boolean isInventoryData) {
         Types.FileHealth fileHealth;
         if (isInventoryData) {
             fileHealth = checkFileValid(Types.SESSIONFILEPATH, VALID_DATAROW_REGEX);

--- a/src/main/java/seedu/duke/utils/Storage.java
+++ b/src/main/java/seedu/duke/utils/Storage.java
@@ -40,6 +40,10 @@ public class Storage {
     private static final String VALID_DATAROW_REGEX =
             "^\\d+,[^,]+,\\d+,\\d+,\\d+(?:\\.\\d+)?,[^,]+,\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{9}$";
     private static final String VALID_ALERT_REGEX = "(.+),\\d+,(min|max)$";
+    private static boolean isStorageWriteDone;
+    public static boolean isStorageWriteDone(){
+        return isStorageWriteDone;
+    }
 
     /**
      * Reads the CSV file from Types.SESSIONFILEPATH and
@@ -123,6 +127,7 @@ public class Storage {
             Ui.printEmptySessionFile();
             return new Inventory();
         }
+
         Ui.printRecoveredSessionFile();
         return inventory;
     }
@@ -133,6 +138,7 @@ public class Storage {
      * @param currentInventory Current inventory
      */
     public static void writeCSV(final Inventory currentInventory) {
+        isStorageWriteDone = false;
         try {
             File dataFolder = new File("./data");
             if (!dataFolder.exists()) {
@@ -151,8 +157,10 @@ public class Storage {
             }
             writer.close();
         } catch (IOException e) {
+            isStorageWriteDone = true;
             System.out.println("Critical: An error occurred when writing to the file.");
         }
+        isStorageWriteDone = true;
     }
 
     public static void writeCSV(final AlertList alertList) {

--- a/src/main/java/seedu/duke/utils/Ui.java
+++ b/src/main/java/seedu/duke/utils/Ui.java
@@ -297,6 +297,13 @@ public class Ui {
         printLine();
     }
 
+    public static void printRaceCondition(){
+        printLine();
+        System.out.println("A rare race condition occurred. Please try restarting the program");
+        System.out.println("If this happens often, check that other programs are not interfering with this one");
+        printLine();
+    }
+
     public static void printSuccessList() {
         printLine();
         System.out.println(INVENTORYLOGO);

--- a/src/test/java/seedu/duke/commands/HistoryCommandTest.java
+++ b/src/test/java/seedu/duke/commands/HistoryCommandTest.java
@@ -68,12 +68,12 @@ public class HistoryCommandTest {
         addParser.run();
         HistoryCommand historyCommand = new HistoryCommand(inventory, "1");
         ArrayList<Item> results = historyCommand.getHistoryResults();
-        assertEquals("uncategorised", results.get(0).getCategory());
+        assertEquals("Uncategorized", results.get(0).getCategory());
         EditParser editParser = new EditParser("upc/1 c/fruits",inventory);
         editParser.run();
         historyCommand = new HistoryCommand(inventory, "1");
         results = historyCommand.getHistoryResults();
-        assertEquals("uncategorised", results.get(0).getCategory());
+        assertEquals("Uncategorized", results.get(0).getCategory());
         assertEquals("fruits", results.get(1).getCategory());
         addParser = new AddParser("n/orange upc/2 qty/5 p/5 c/fruits", inventory);
         addParser.run();

--- a/src/test/java/seedu/duke/parsers/AddParserTest.java
+++ b/src/test/java/seedu/duke/parsers/AddParserTest.java
@@ -1,7 +1,8 @@
-package seedu.duke.utils.parsers;
+package seedu.duke.parsers;
 
 import org.junit.jupiter.api.Test;
 import seedu.duke.objects.Inventory;
+import seedu.duke.utils.parsers.AddParser;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;

--- a/src/test/java/seedu/duke/utils/StorageTest.java
+++ b/src/test/java/seedu/duke/utils/StorageTest.java
@@ -22,7 +22,7 @@ class StorageTest {
         addCommand.run();
         Storage.writeCSV(testInventory);
         try {
-            Thread.sleep(100);
+            Thread.sleep(500);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
         }

--- a/src/test/java/seedu/duke/utils/StorageTest.java
+++ b/src/test/java/seedu/duke/utils/StorageTest.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 class StorageTest {
 
     @Test
-    synchronized void testCSVReadWrite() {
+    public synchronized void testCSVReadWrite() {
         Inventory testInventory = new Inventory();
         Item testItem = new Item("testItem", "123456789012", 10, 10.0, LocalDateTime.now());
         Item testItem2 = new Item("testItem2", "123456789013", 10, 10.0, LocalDateTime.now());

--- a/src/test/java/seedu/duke/utils/StorageTest.java
+++ b/src/test/java/seedu/duke/utils/StorageTest.java
@@ -21,6 +21,11 @@ class StorageTest {
         addCommand = new AddCommand(testInventory, testItem2);
         addCommand.run();
         Storage.writeCSV(testInventory);
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
         Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem));
         Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem2));
     }

--- a/src/test/java/seedu/duke/utils/StorageTest.java
+++ b/src/test/java/seedu/duke/utils/StorageTest.java
@@ -23,10 +23,10 @@ class StorageTest {
         Storage.writeCSV(testInventory);
         try {
             Thread.sleep(500);
+            Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem));
+            Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem2));
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
         }
-        Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem));
-        Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem2));
     }
 }

--- a/src/test/java/seedu/duke/utils/StorageTest.java
+++ b/src/test/java/seedu/duke/utils/StorageTest.java
@@ -21,13 +21,6 @@ class StorageTest {
         addCommand = new AddCommand(testInventory, testItem2);
         addCommand.run();
         Storage.writeCSV(testInventory);
-        while(!Storage.isStorageWriteDone()){
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-            }
-        }
         Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem));
         Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem2));
     }

--- a/src/test/java/seedu/duke/utils/StorageTest.java
+++ b/src/test/java/seedu/duke/utils/StorageTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import seedu.duke.commands.AddCommand;
 import seedu.duke.objects.Inventory;
 import seedu.duke.objects.Item;
+import seedu.duke.types.Types;
 
 import java.time.LocalDateTime;
 
@@ -20,7 +21,7 @@ class StorageTest {
         addCommand = new AddCommand(testInventory, testItem2);
         addCommand.run();
         Storage.writeCSV(testInventory);
-        Assertions.assertTrue(Storage.readCSV().getItemInventory().contains(testItem));
-        Assertions.assertTrue(Storage.readCSV().getItemInventory().contains(testItem2));
+        Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem));
+        Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem2));
     }
 }

--- a/src/test/java/seedu/duke/utils/StorageTest.java
+++ b/src/test/java/seedu/duke/utils/StorageTest.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 class StorageTest {
 
     @Test
-    void testCSVReadWrite() {
+    synchronized void testCSVReadWrite() {
         Inventory testInventory = new Inventory();
         Item testItem = new Item("testItem", "123456789012", 10, 10.0, LocalDateTime.now());
         Item testItem2 = new Item("testItem2", "123456789013", 10, 10.0, LocalDateTime.now());
@@ -21,12 +21,14 @@ class StorageTest {
         addCommand = new AddCommand(testInventory, testItem2);
         addCommand.run();
         Storage.writeCSV(testInventory);
-        try {
-            Thread.sleep(500);
-            Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem));
-            Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem2));
-        } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
+        while(!Storage.isStorageWriteDone()){
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
         }
+        Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem));
+        Assertions.assertTrue(Storage.readCSV(Types.SESSIONFILEPATH).getItemInventory().contains(testItem2));
     }
 }


### PR DESCRIPTION
Harden AlertList load against: upc does not exist, alert is neither min nor max, extra space on either sides or the line
Remove string literals in filtercommand
Fixed add command setting category to uncategorised instead of Uncategorized
Refactor SessionManager to read from file path for future testing
readCSV function now use checkFileValid to fix weird error message
inventory readCSV now checks for localDateTime integrity and quantity in range
alert readCSV now checks if upcCodes are in inventory
alert readCSV now prints error instead of empty file in the event of NumberFormatException
Fix history command test using old default category


closes #125 