### PR TITLE
Add printing of alert warnings when alerts are created

### DIFF
--- a/src/main/java/seedu/duke/commands/AddAlertCommand.java
+++ b/src/main/java/seedu/duke/commands/AddAlertCommand.java
@@ -33,10 +33,10 @@ public class AddAlertCommand extends Command  {
     private void addAlert() {
         if (alert.getMinmax().equals(MIN_KEYWORD)) {
             addMinAlert();
-        }
-
-        if (alert.getMinmax().equals(MAX_KEYWORD)) {
+        } else if (alert.getMinmax().equals(MAX_KEYWORD)) {
             addMaxAlert();
+        } else {
+            assert false: Ui.printInvalidAlertType();
         }
     }
 
@@ -46,6 +46,9 @@ public class AddAlertCommand extends Command  {
                 alertList.setMinAlertUpcs(alert.getUpc(), alert.getStock());
                 Ui.printSuccessAddAlert();
                 SessionManager.writeSession(alertList);
+
+                alertList.checkAlerts(alert.getUpc(), inventory.getUpcCodes().get(alert.getUpc()).getName(),
+                        inventory.getUpcCodes().get(alert.getUpc()).getQuantity());
 
             } else {
                 Ui.printInvalidMinAlert();
@@ -62,6 +65,9 @@ public class AddAlertCommand extends Command  {
                 alertList.setMaxAlertUpcs(alert.getUpc(), alert.getStock());
                 Ui.printSuccessAddAlert();
                 SessionManager.writeSession(alertList);
+
+                alertList.checkAlerts(alert.getUpc(), inventory.getUpcCodes().get(alert.getUpc()).getName(),
+                        inventory.getUpcCodes().get(alert.getUpc()).getQuantity());
             } else {
                 Ui.printInvalidMaxAlert();
             }

--- a/src/main/java/seedu/duke/utils/Ui.java
+++ b/src/main/java/seedu/duke/utils/Ui.java
@@ -173,6 +173,9 @@ public class Ui {
 
     private static final String NONEXISTENT_REMOVE_ALERT = "The alert that you are attempting to remove " +
             "does not exist.";
+
+    private static final String INVALID_ALERT_TYPE = "Alert is not a valid type (min/max)";
+
     private static final String INVALID_CATEGORY_FORMAT = "Wrong/Incomplete Format! Please enter category commands " +
             "as shown below.\n" + "List all categories: cat list\n" + "List all items in a category: cat [Category]\n" +
             "List all items and all categories: cat table";
@@ -394,11 +397,11 @@ public class Ui {
             headings = new String[] {INDEX_HEADING, NAME_HEADING, UPC_HEADING, QTY_HEADING, PRICE_HEADING,
                 CATEGORY_HEADING};
         } else if (columnWidths.length == HELP_ATTRIBUTE_COUNT && columnWidths[0] == COMMAND_COL_WIDTH) {
-            headings = new String[]{COMMAND_HEADING, FORMAT_HEADING};
+            headings = new String[] {COMMAND_HEADING, FORMAT_HEADING};
         } else if (columnWidths.length == ALERT_ATTRIBUTE_COUNT) {
-            headings = new String[]{"Name", "UPC", "Stock"};
+            headings = new String[] {"Name", "UPC", "Stock"};
         } else if (columnWidths.length == HELP_ATTRIBUTE_COUNT && columnWidths[0] == CATEGORY_COL_WIDTH) {
-            headings = new String[]{CATEGORY_HEADING, NAME_HEADING + ": " + UPC_HEADING};
+            headings = new String[] {CATEGORY_HEADING, NAME_HEADING + ": " + UPC_HEADING};
         }
         StringBuilder allHeadings = new StringBuilder();
 
@@ -895,6 +898,14 @@ public class Ui {
         printLine();
         System.out.println(NONEXISTENT_REMOVE_ALERT);
         printLine();
+    }
+
+    public static String printInvalidAlertType() {
+        StringBuilder sb = new StringBuilder("");
+        sb.append(LINE);
+        sb.append(INVALID_ALERT_TYPE);
+        sb.append(LINE);
+        return sb.toString();
     }
 
     private static String printAlerts(Inventory inventory, AlertList alertList) {


### PR DESCRIPTION
When a min/max alert is added for an item whose quantity is already below the min alert level/above the max alert level, a warning is printed when the alert is added.

![min_alert_warning](https://user-images.githubusercontent.com/88529907/229760585-6e2b10ad-e222-4821-ad3f-dba2d672c536.PNG)

![max_alert_warning](https://user-images.githubusercontent.com/88529907/229760589-b56fcb64-e218-451c-849f-ad908648dfe9.PNG)
